### PR TITLE
Correction of EA and GA for nondeterministic fitness functions

### DIFF
--- a/Solid/EvolutionaryAlgorithm.py
+++ b/Solid/EvolutionaryAlgorithm.py
@@ -132,7 +132,7 @@ class EvolutionaryAlgorithm:
         shuffle(self.population)
         total_fitness = sum(self.fitnesses)
         if total_fitness != 0:
-            probs = list([self._fitness(x) / total_fitness for x in self.population])
+            probs = list([self.fitnesses[i] / total_fitness for i in range(len(self.population))])
         else:
             return self.population[0:n]
         res = []

--- a/Solid/GeneticAlgorithm.py
+++ b/Solid/GeneticAlgorithm.py
@@ -133,7 +133,7 @@ class GeneticAlgorithm:
         shuffle(self.population)
         total_fitness = sum(self.fitnesses)
         if total_fitness != 0:
-            probs = list([self._fitness(x) / total_fitness for x in self.population])
+            probs = list([self.fitnesses[i] / total_fitness for i in range(len(self.population))])
         else:
             return self.population[0:n]
         res = []


### PR DESCRIPTION
Correction of an issue that occurs when the fitness function is nondeterministic (shuffled cross-validation for example). In the `_select_n` method, the total fitness is computed according to the stored fitnesses, but the `probs` variable is computed according to recalculated fitness values.
This slight change makes the method use the stored fitnesses at each time, which solves the problem.
This also makes the method run much faster (especially when the fitness function has a high complexity) by removing unnecessary calls to `_fitness`.